### PR TITLE
updated ui design of forgot password

### DIFF
--- a/app/Http/Controllers/Auth/PasswordResetLinkController.php
+++ b/app/Http/Controllers/Auth/PasswordResetLinkController.php
@@ -36,6 +36,8 @@ class PasswordResetLinkController extends Controller
             $request->only('email')
         );
 
+        // dd($status);
+
         return $status == Password::RESET_LINK_SENT
                     ? back()->with('status', __($status))
                     : back()->withInput($request->only('email'))

--- a/resources/views/auth/forgot-password.blade.php
+++ b/resources/views/auth/forgot-password.blade.php
@@ -1,4 +1,4 @@
-<x-guest-layout>
+{{-- <x-guest-layout>
     <div class="mb-4 text-sm text-gray-600">
         {{ __('Forgot your password? No problem. Just let us know your email address and we will email you a password reset link that will allow you to choose a new one.') }}
     </div>
@@ -22,4 +22,32 @@
             </x-primary-button>
         </div>
     </form>
-</x-guest-layout>
+</x-guest-layout> --}}
+
+
+@extends('layouts.guest')
+
+@section('content')
+<div class="container">
+    <div class="row flex-center min-vh-100 py-5">
+      <div class="col-sm-10 col-md-8 col-lg-5 col-xxl-4"><a class="d-flex flex-center text-decoration-none mb-4" href="{{ route('home') }}">
+          <div class="d-flex align-items-center fw-bolder fs-3 d-inline-block"><img src="{{ asset('ui/assets/img/favicon.png') }}" alt="phoenix" width="58" /></div>
+        </a>
+        <div class="px-xxl-5">
+          <div class="text-center mb-6">
+            <h4 class="text-body-highlight">Forgot your password?</h4>
+            <p class="text-body-tertiary mb-5">Enter your email below and we will send <br class="d-sm-none" />you a reset link</p>
+            <form class="d-flex align-items-center mb-5" method="POST" action="{{ route('password.email') }}">
+                @csrf
+                <input class="form-control flex-1" id="email" type="email" name="email" required autofocus placeholder="Email" />
+                <button type="submit" class="btn btn-primary ms-2">
+                    Send<span class="fas fa-chevron-right ms-2"></span>
+                </button>
+            </form>
+            <a class="fs-9 fw-bold" href="#!">Still having problems?</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+@endsection


### PR DESCRIPTION
This pull request includes changes to the password reset functionality and the associated view template. The main changes involve debugging code in the password reset controller and a significant update to the `forgot-password` Blade template to improve the user interface and layout.

Changes to password reset functionality:

* [`app/Http/Controllers/Auth/PasswordResetLinkController.php`](diffhunk://#diff-9a2380c1819c5c049d69b9bc92d6c6c04e283f546e2a9862e74aaebe486c4c6dR39-R40): Added a debugging statement (`dd($status)`) to the `store` method to facilitate troubleshooting of password reset link issues.

Updates to the `forgot-password` Blade template:

* [`resources/views/auth/forgot-password.blade.php`](diffhunk://#diff-7b474cbc38482e78ab8214ec239adb703c5c758c13663f954609dcd6ddf41b3aL1-R1): Replaced the `x-guest-layout` component with a custom layout using the `@extends` directive and added a new section for the content. This includes a new form layout with improved styling and structure for better user experience. [[1]](diffhunk://#diff-7b474cbc38482e78ab8214ec239adb703c5c758c13663f954609dcd6ddf41b3aL1-R1) [[2]](diffhunk://#diff-7b474cbc38482e78ab8214ec239adb703c5c758c13663f954609dcd6ddf41b3aL25-R53)