### PR TITLE
fetch respective event from the event types

### DIFF
--- a/app/Http/Controllers/EventController.php
+++ b/app/Http/Controllers/EventController.php
@@ -69,7 +69,26 @@ class EventController extends Controller
     }
 
     public function viewEvents(){
-        $events = Program::where('event_date','>=',now())->get();
+        switch (Auth::user()->role) {
+            case 'student':
+                // Code for student
+                $events = Program::where('event_date', '>=', now())->where('type', '!=', 'FDP')->get();
+                break;
+            case 'faculty':
+                // Code for faculty
+                $events = Program::where('event_date', '>=', now())->where('type', '!=', 'SDP')->get();
+                break;
+            case 'HoD':
+                // Code for HoD
+                $events = Program::where('event_date', '>=', now())->where('type', '!=', 'SDP')->get();
+                break;
+            case 'Principle':
+                $events = Program::where('event_date', '>=', now())->where('type', '!=', 'SDP')->get();
+                break;
+            default:
+                // Code for default case
+                break;
+        }
         // dd($events);
         return view('dashboard.events.index', compact('events'));
     }

--- a/resources/views/dashboard/events/index.blade.php
+++ b/resources/views/dashboard/events/index.blade.php
@@ -38,10 +38,12 @@
 
     <div class="row justify-content-between align-items-end mb-9 me-0 g-4">
         @foreach ($events as $event)
-        <div class="card" style="max-width:20rem;">
-            <img class="card-img-top p-1" src="{{ Storage::url($event->banner) }}" alt="{{ $event->name }}">
-            <h4 class="mt-2">{{ $event->name }}</h4>
-        </div>
+        <a class="p-3" href="{{ route('events.show', $event->id) }}" target="_blank" style="text-decoration: none;">
+            <div class="card" style="max-width:20rem;">
+                <img class="card-img-top p-1" src="{{ Storage::url($event->banner) }}" alt="{{ $event->name }}">
+                <h4 class="mt-2 px-2">{{ $event->name }}</h4>
+            </div>
+        </a>
         @endforeach
     </div>
 </div>


### PR DESCRIPTION
This pull request includes changes to the `EventController` and the event display in the dashboard view. The most important changes include adding role-based filtering for events and modifying the event card display to include a clickable link.

Role-based filtering for events:

* [`app/Http/Controllers/EventController.php`](diffhunk://#diff-e9e47c7018c1905fd246eae03c806f9201694932ce9a583c41431dc8896bcbdcL72-R91): Added a switch case to filter events based on the user's role, ensuring that students, faculty, HoD, and Principle see different event types.

Event card display modification:

* [`resources/views/dashboard/events/index.blade.php`](diffhunk://#diff-fb30b4740539b5fb4d75dc8971d46f816bea35fc2a5604bdf6585b38baf0bf66R41-R46): Wrapped the event card in an anchor tag to make the entire card clickable, linking to the event details page.