### PR TITLE
done crud of user testimonials

### DIFF
--- a/app/Http/Controllers/TestimonialController.php
+++ b/app/Http/Controllers/TestimonialController.php
@@ -10,9 +10,9 @@ class TestimonialController extends Controller
 {
     public function index(){
         $user = Auth::user();
-        $testimonial = Testimonials::where('user_id', $user->id)->first();
+        $testimonials = Testimonials::where('user_id', $user->id)->first();
         // dd($testimonials);
-        return view('dashboard.testimonial.index', compact('testimonial'));
+        return view('dashboard.testimonial.index', compact('testimonials'));
     }
 
     public function create(){
@@ -22,5 +22,49 @@ class TestimonialController extends Controller
     public function edit(){
         $testimonial = Testimonials::where('user_id', Auth::user()->id)->first();
         return view('dashboard.testimonial.edit', compact('testimonial'));
+    }
+
+    public function store(Request $request){
+
+        // dd($request->all());
+        $request->validate([
+            'title' => 'required|min:5',
+            'testimonial' => 'required',
+        ]);
+
+        $testimonial = new Testimonials();
+        $testimonial->user_id = Auth::user()->id;
+        $testimonial->title = $request->title;
+        $testimonial->testimonial = $request->testimonial;
+        $testimonial->save();
+
+        // dd("done save");
+
+        return redirect()->route('user.testimonials')->with('success', 'Testimonial added successfully');
+    }
+
+    public function update(Request $request, $id){
+        // dd($request->all());
+        $request->validate([
+            'title' => 'required|min:5',
+            'testimonial' => 'required',
+        ]);
+
+        $testimonial = Testimonials::find($id);
+
+        $testimonial->update([
+            'title' => $request->title,
+            'testimonial' => $request->testimonial,
+        ]);
+
+        // dd("done update");
+        return redirect()->route('user.testimonials')->with('success', 'Testimonial updated successfully');
+    }
+
+    public function destroy($id){
+        $testimonial = Testimonials::find($id);
+        $testimonial->delete();
+
+        return redirect()->route('user.testimonials')->with('success', 'Testimonial deleted successfully');
     }
 }

--- a/resources/views/dashboard/testimonial/create.blade.php
+++ b/resources/views/dashboard/testimonial/create.blade.php
@@ -3,54 +3,67 @@
 @section('content')
 <div class="card mb-5">
     <div class="card-header d-flex justify-content-center align-items-end position-relative mb-7 mb-xxl-0"
-        style="min-height: 214px; ">
+        style="min-height: 214px;">
         <div class="hover-actions-trigger position-static">
             <div class="bg-holder rounded-top" style="background-image:url(../../assets/img/generic/cover-photo.png);">
             </div>
-            {{-- <input class="d-none" id="upload-cover-image" type="file" />
-            <label class="cover-image-file-input" for="upload-cover-image"></label> --}}
             <div class="hover-actions end-0 bottom-0 pe-1 pb-2 text-white">
                 <span class="fa-solid fa-camera me-2 overlay-icon"></span>
             </div>
-            <!--/.bg-holder-->
         </div>
-        {{-- <input class="d-none" id="upload-porfile-picture" type="file" /> --}}
         <div class="hoverbox feed-profile" style="width: 150px; height: 150px">
-            <div class="rounded-circle d-flex flex-center z-1" style="--phoenix-bg-opacity: .56;">
-                {{-- <span class="fa-solid fa-camera fs-3 text-secondary-light"></span> --}}
-            </div>
             <div class="position-relative bg-body-quaternary rounded-circle cursor-pointer d-flex flex-center mb-xxl-7">
                 <div class="avatar avatar-5xl">
                     <img class="rounded-circle rounded-circle img-thumbnail shadow-sm border-0"
                         src="{{ Storage::url(Auth::user()->image) }}" alt="{{ Auth::user()->name }}" />
                 </div>
-                {{-- <label class="w-100 h-100 position-absolute z-1" for="upload-porfile-picture"></label> --}}
             </div>
         </div>
     </div>
     <div class="card-body">
-        <div class="row justify-content-xl-between">
-            <div class="col-auto">
-                <div class="d-flex flex-wrap mb-3 align-items-center">
-                    <h2 class="me-2">{{ Auth::user()->name }}</h2>
-                    {{-- <span class="fw-semibold fs-7 text-body-emphasis">u/hansolo</span> --}}
-                </div>
-            </div>
-            <div class="col-12 gy-6">
-                <div class="form-floating"><textarea class="form-control" id="floatingProjectOverview"
-                        placeholder="Leave a comment here" style="height: 100px"></textarea><label
-                        for="floatingProjectOverview">Your Experience</label></div>
-            </div>
-            <div class="col-12 gy-6">
-                <div class="row g-3 justify-content-end">
-                    <div class="col-auto"><a href="my_testimonial.html"><button
-                                class="btn btn-phoenix-primary px-5">Cancel</button></a>
-                    </div>
-                    <div class="col-auto"><button class="btn btn-primary px-5 ">Add</button>
+        <form action="{{ route('user.testimonial.store') }}" method="POST">
+            @csrf
+            <div class="row justify-content-xl-between">
+                <div class="col-auto">
+                    <div class="d-flex flex-wrap mb-3 align-items-center">
+                        <h2 class="me-2">{{ Auth::user()->name }}</h2>
                     </div>
                 </div>
+                <div class="col-12 gy-6">
+                    {{-- Title Field --}}
+                    <div class="form-floating mb-4">
+                        <input type="text" class="form-control @error('title') is-invalid @enderror" 
+                               id="floatingProjectTitle" placeholder="Testimonial Title" name="title"
+                               value="{{ old('title') }}" />
+                        <label for="floatingProjectTitle">Title</label>
+                        @error('title')
+                            <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
+
+                    {{-- Testimonial Field --}}
+                    <div class="form-floating">
+                        <textarea class="form-control @error('testimonial') is-invalid @enderror" 
+                                  id="floatingProjectOverview" placeholder="Leave a comment here" 
+                                  style="height: 50px" name="testimonial">{{ old('testimonial') }}</textarea>
+                        <label for="floatingProjectOverview">Your Experience</label>
+                        @error('testimonial')
+                            <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
+                </div>
+                <div class="col-12 gy-6">
+                    <div class="row g-3 justify-content-end">
+                        <div class="col-auto">
+                            <a href="{{ route('user.testimonials') }}" class="btn btn-phoenix-primary px-5">Cancel</a>
+                        </div>
+                        <div class="col-auto">
+                            <button type="submit" class="btn btn-primary px-5">Add</button>
+                        </div>
+                    </div>
+                </div>
             </div>
-        </div>
+        </form>
     </div>
 </div>
 @endsection

--- a/resources/views/dashboard/testimonial/edit.blade.php
+++ b/resources/views/dashboard/testimonial/edit.blade.php
@@ -3,62 +3,66 @@
 @section('content')
 <div class="card mb-5">
     <div class="card-header d-flex justify-content-center align-items-end position-relative mb-7 mb-xxl-0"
-        style="min-height: 214px; ">
+        style="min-height: 214px;">
         <div class="hover-actions-trigger position-static">
             <div class="bg-holder rounded-top" style="background-image:url(../../assets/img/generic/cover-photo.png);">
             </div>
-            {{-- <input class="d-none" id="upload-cover-image" type="file" />
-            <label class="cover-image-file-input" for="upload-cover-image"></label> --}}
             <div class="hover-actions end-0 bottom-0 pe-1 pb-2 text-white">
                 <span class="fa-solid fa-camera me-2 overlay-icon"></span>
             </div>
-            <!--/.bg-holder-->
         </div>
-        {{-- <input class="d-none" id="upload-porfile-picture" type="file" /> --}}
         <div class="hoverbox feed-profile" style="width: 150px; height: 150px">
-            <div class="rounded-circle d-flex flex-center z-1" style="--phoenix-bg-opacity: .56;">
-                {{-- <span class="fa-solid fa-camera fs-3 text-secondary-light"></span> --}}
-            </div>
             <div class="position-relative bg-body-quaternary rounded-circle cursor-pointer d-flex flex-center mb-xxl-7">
                 <div class="avatar avatar-5xl">
                     <img class="rounded-circle rounded-circle img-thumbnail shadow-sm border-0"
                         src="{{ Storage::url(Auth::user()->image) }}" alt="{{ Auth::user()->name }}" />
                 </div>
-                {{-- <label class="w-100 h-100 position-absolute z-1" for="upload-porfile-picture"></label> --}}
             </div>
         </div>
     </div>
     <div class="card-body">
-        <div class="row justify-content-xl-between">
-            <div class="col-auto">
-                <div class="d-flex flex-wrap mb-3 align-items-center">
-                    {{-- <h2 class="me-2">{{ $testimonial->title }}</h2> --}}
-                    <input type="text" for="title" class="form-control" value="{{ $testimonial->title }}">
-                    {{-- <span class="fw-semibold fs-7 text-body-emphasis">u/hansolo</span> --}}
-                </div>
-            </div>
-            <div class="col-12 gy-6">
-                <div class="form-floating">
-                    <textarea class="form-control" id="floatingProjectOverview" placeholder="Leave a comment here" style="height: 100px">{{ $testimonial->testimonial }}</textarea>
-                    <label for="floatingProjectOverview">Your Testimonial</label>
-                </div>
-            </div>
-            <div class="col-12 gy-6">
-                <div class="row g-3 justify-content-end">
-                    <div class="col-auto">
-                        <a href="{{ route('user.testimonials') }}">
-                            <button class="btn btn-phoenix-primary px-5">Cancel</button>
-                        </a>
-                    </div>
-                    <div class="col-auto">
-                        <form action="#" method="POST">
-                            @csrf
-                            <button class="btn btn-primary px-5 ">Add</button>
-                        </form>
+        <form action="{{ route('user.testimonial.update', $testimonial->id) }}" method="POST">
+            @csrf
+            <div class="row justify-content-xl-between">
+                <div class="col-auto">
+                    <div class="d-flex flex-wrap mb-3 align-items-center">
+                        <h2 class="me-2">{{ Auth::user()->name }}</h2>
                     </div>
                 </div>
+                <div class="col-12 gy-6">
+                    {{-- Title Field --}}
+                    <div class="form-floating mb-4">
+                        <input type="text" class="form-control @error('title') is-invalid @enderror" id="floatingProjectTitle" placeholder="Testimonial Title" name="title"
+                               value="{{ $testimonial->title }}" />
+                        <label for="floatingProjectTitle">Title</label>
+                        @error('title')
+                            <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
+
+                    {{-- Testimonial Field --}}
+                    <div class="form-floating">
+                        <textarea class="form-control @error('testimonial') is-invalid @enderror" 
+                                  id="floatingProjectOverview" placeholder="Leave a comment here" 
+                                  style="height: 50px" name="testimonial">{{ $testimonial->testimonial }}</textarea>
+                        <label for="floatingProjectOverview">Your Experience</label>
+                        @error('testimonial')
+                            <div class="invalid-feedback">{{ $message }}</div>
+                        @enderror
+                    </div>
+                </div>
+                <div class="col-12 gy-6">
+                    <div class="row g-3 justify-content-end">
+                        <div class="col-auto">
+                            <a href="{{ route('user.testimonials') }}" class="btn btn-phoenix-primary px-5">Cancel</a>
+                        </div>
+                        <div class="col-auto">
+                            <button type="submit" class="btn btn-primary px-5">Update</button>
+                        </div>
+                    </div>
+                </div>
             </div>
-        </div>
+        </form>
     </div>
 </div>
 @endsection

--- a/resources/views/dashboard/testimonial/index.blade.php
+++ b/resources/views/dashboard/testimonial/index.blade.php
@@ -1,6 +1,9 @@
 @extends('layouts.dashboard.dashboard')
 
 @section('content')
+@if (!$testimonials)
+    <h1>No Testimonials</h1>
+@else
 <div class="card mb-5">
     <div class="card-header d-flex justify-content-center align-items-end position-relative mb-7 mb-xxl-0"
         style="min-height: 214px; ">
@@ -45,9 +48,12 @@
                         </a>
                     </div>
                     <div class="col-auto order-xxl-2">
-                        <button class="btn btn-danger lh-1">
-                            <span class=" me-2" data-feather="trash"></span>Delete
-                        </button>
+                        <form action="{{ route('user.testimonial.destroy', $testimonials->id) }}" method="POST">
+                            @csrf
+                            <button type="submit" class="btn btn-danger lh-1">
+                                <span class=" me-2" data-feather="trash"></span>Delete
+                            </button>
+                        </form>
                     </div>
                     {{-- <div class="col-auto order-xxl-1">
                         <button class="btn btn-phoenix-primary lh-1">
@@ -60,4 +66,5 @@
         </div>
     </div>
 </div>
+@endif
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -48,7 +48,11 @@ Route::post('/user-dashboard/delete-activity/{id}',[ActivityController::class,'d
 
 Route::get('/user-dashboard/my-testimonials',[TestimonialController::class,'index'])->name('user.testimonials')->middleware('auth');
 Route::get('/user-dashboard/add-testimonial',[TestimonialController::class,'create'])->name('user.testimonial.create')->middleware('auth');
+Route::post('/user-dashboard/add-testimonial',[TestimonialController::class,'store'])->name('user.testimonial.store')->middleware('auth');
 Route::get('/user-dashboard/edit-testimonial',[TestimonialController::class,'edit'])->name('user.testimonial.edit')->middleware('auth');
+Route::post('/user-dashboard/update-testimonial/{id}',[TestimonialController::class,'update'])->name('user.testimonial.update')->middleware('auth');
+Route::post('/user-dashboard/delete-testimonial/{id}',[TestimonialController::class,'destroy'])->name('user.testimonial.destroy')->middleware('auth');
+
 Route::get('/user-dashboard/students',[StudentController::class,'index'])->name('user.students')->middleware('auth');
 Route::get('/user-dashboard/add-students',[StudentController::class,'create'])->name('user.students.create')->middleware('auth');
 


### PR DESCRIPTION
This pull request introduces several changes to the `TestimonialController` and related views to enhance testimonial management functionality. The most significant changes include adding CRUD operations for testimonials, updating the corresponding views to handle these operations, and making necessary route adjustments.

### Controller Enhancements:
* Added `store`, `update`, and `destroy` methods to `TestimonialController` for handling testimonial creation, updating, and deletion.

### View Updates:
* Updated `create.blade.php` to include a form for adding testimonials with validation and error handling.
* Updated `edit.blade.php` to include a form for editing testimonials with validation and error handling.
* Updated `index.blade.php` to handle the display of testimonials and added a conditional message for when no testimonials are present. [[1]](diffhunk://#diff-c1017659e2696df40418c6d41273c144b0628abb6664774844b82d008bb112faR4-R6) [[2]](diffhunk://#diff-c1017659e2696df40418c6d41273c144b0628abb6664774844b82d008bb112faR69)
* Added a form for deleting testimonials in `index.blade.php`.

### Route Adjustments:
* Added new routes for storing, updating, and deleting testimonials in `web.php`.