### PR TITLE
updated tests.yml and push.yml

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,45 @@
+name: Mantan
+on:
+  push:
+    branches: 
+      - "main"
+  pull_request:
+    branches: 
+      - "main"
+jobs:
+  dev-branch-tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: shivammathur/setup-php@15c43e89cdef867065b0213be354c2841860869e
+      with:
+        php-version: '8.2'
+    - uses: actions/checkout@v4
+    - name: Copy .env
+      run: php -r "file_exists('.env') || copy('.env.example', '.env');"
+    - name: Update composer
+      run: composer update -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
+    - name: Install Dependencies
+      run: composer install -q --no-ansi --no-interaction --no-scripts --no-progress --prefer-dist
+    - name: Generate key
+      run: php artisan key:generate
+    - name: Directory Permissions
+      run: chmod -R 777 storage bootstrap/cache
+    - name: Create Database
+      run: |
+        mkdir -p database
+        touch database/database.sqlite
+    - name: Setup Node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: '20'
+    - name: Install npm dependencies
+      run: npm install
+    - name: Build assets
+      run: npm run build
+    - name: List build directory
+      run: ls -la public/build # Debugging step to check if manifest.json is generated
+    - name: Execute tests (Unit and Feature tests) via PHPUnit/Pest
+      env:
+        DB_CONNECTION: sqlite
+        DB_DATABASE: database/database.sqlite
+      run: php artisan test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,1 +1,53 @@
-
+name: Tests
+on:
+  push:
+    branches:
+      - main
+      - '*.x'
+  pull_request:
+  schedule:
+    - cron: '0 0 * * *'
+permissions:
+  contents: read
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        php: [8.2, 8.3]
+    name: PHP ${{ matrix.php }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite
+          coverage: none
+      - name: Update Composer dependencies
+        run: composer update --prefer-dist --no-interaction --no-progress
+      - name: Install Composer dependencies
+        run: composer install --prefer-dist --no-interaction --no-progress
+      - name: Copy environment file
+        run: cp .env.example .env
+      - name: Generate app key
+        run: php artisan key:generate
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - name: Install npm dependencies
+        run: npm install
+      - name: Build assets
+        run: npm run build
+      - name: Setup SQLite Database
+        run: |
+          touch database/database.sqlite
+          php artisan migrate --force
+      - name: Execute tests
+        env:
+          DB_CONNECTION: sqlite
+          DB_DATABASE: database/database.sqlite
+        run: vendor/bin/pest


### PR DESCRIPTION
This pull request introduces new workflows for continuous integration and testing. The changes include adding a new workflow for running tests on the `main` branch and pull requests, and another workflow for scheduled tests and tests on multiple PHP versions.

New workflows for CI and testing:

* [`.github/workflows/push.yml`](diffhunk://#diff-f3fc934cf0d89bdf07de358896ff90f1202585df812cf606206d1830a9949811R1-R45): Added a workflow named "Mantan" that runs on `push` and `pull_request` events for the `main` branch. This workflow sets up PHP, installs dependencies, sets up the environment, and runs tests using PHPUnit/Pest.
* [`.github/workflows/tests.yml`](diffhunk://#diff-1db27d93186e46d3b441ece35801b244db8ee144ff1405ca27a163bfe878957fL1-R53): Added a workflow named "Tests" that runs on `push` events for the `main` branch and branches matching `*.x`, as well as on a daily schedule. This workflow tests the code on PHP versions 8.2 and 8.3, sets up the environment, installs dependencies, and executes tests using Pest.