### PR TITLE
update: no data displays

### DIFF
--- a/resources/views/blog/index.blade.php
+++ b/resources/views/blog/index.blade.php
@@ -27,7 +27,7 @@
         <div class="row">
             @if ($posts->isEmpty())
             <center>
-                <h1 class="display-4">No Posts Available</h1>
+                <h1 class="display-4">No Blogs Available</h1>
             </center>
             @else
             <div class="col-lg-8">

--- a/resources/views/events/index.blade.php
+++ b/resources/views/events/index.blade.php
@@ -24,6 +24,11 @@
 <section class="features-event pt-120 pb-120">
     <div class="container">
         <div class="row gy-4 justify-content-center">
+            @if ($programs->isEmpty())
+            <center>
+                <h1 class="display-4">No Events Available</h1>
+            </center>
+            @else
             @foreach ($programs as $program)
             <div class="col-lg-4 col-md-6">
                 <div class="event-item wow fade-in-bottom" data-wow-delay="400ms">
@@ -46,6 +51,7 @@
                 </div>
             </div>
             @endforeach
+            @endif
         </div>
     </div>
 </section>

--- a/resources/views/gallery/index.blade.php
+++ b/resources/views/gallery/index.blade.php
@@ -23,6 +23,11 @@
 <section class="team-section pt-120 pb-120">
     <div class="container">
         <div class="row gy-4 justify-content-center">
+            @if ($gallery->isEmpty())
+                <center>
+                    <h1 class="display-4">No Galleries Available</h1>
+                </center>
+            @else
             @foreach ($gallery as $item)    
             <div class="col-xl-4 col-lg-4 col-md-6">
                 <div class="team-item-2 wow fade-in-bottom" data-wow-delay="200ms">
@@ -41,6 +46,7 @@
                 </div>
             </div>
             @endforeach
+            @endif
         </div>
     </div>
 </section>


### PR DESCRIPTION
This pull request includes updates to the views for blog, events, and gallery pages to handle empty states more gracefully by displaying appropriate messages when there are no items available.

Changes to handle empty states:

* [`resources/views/blog/index.blade.php`](diffhunk://#diff-fcda2be38a1523627ae06f1edb5bcba24394bd34dd699b52c3c8220fa91f46eaL30-R30): Updated the message displayed when no blog posts are available from "No Posts Available" to "No Blogs Available".
* [`resources/views/events/index.blade.php`](diffhunk://#diff-d857b3c45fcf9892bddfbe9b7231b5dccab2edd9123d0775c124f436c5a26dc6R27-R31): Added a condition to display "No Events Available" when there are no events and ensured proper closure of the conditional block. [[1]](diffhunk://#diff-d857b3c45fcf9892bddfbe9b7231b5dccab2edd9123d0775c124f436c5a26dc6R27-R31) [[2]](diffhunk://#diff-d857b3c45fcf9892bddfbe9b7231b5dccab2edd9123d0775c124f436c5a26dc6R54)
* [`resources/views/gallery/index.blade.php`](diffhunk://#diff-acd526a5c766c452685661ddcead970db6c8dcbe6c88a098a8d23a84def410daR26-R30): Added a condition to display "No Galleries Available" when there are no gallery items and ensured proper closure of the conditional block. [[1]](diffhunk://#diff-acd526a5c766c452685661ddcead970db6c8dcbe6c88a098a8d23a84def410daR26-R30) [[2]](diffhunk://#diff-acd526a5c766c452685661ddcead970db6c8dcbe6c88a098a8d23a84def410daR49)